### PR TITLE
PHP8 - add used properties to all classes to avoid dynamic property deprecation

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,0 +1,9 @@
+# AskNicely Mandrill API
+
+This is a direct clone of the last known version of the `mandrill/mandrill` package before it was abandoned. See https://bitbucket.org/mailchimp/mandrill-api-php/src/master/
+
+We were pulling `mandrill/mandrill` in via our composer, so the first commit to this repo is exactly what we have been using.
+
+Subsequent commits are minor tweaks to get around PHP 8 issues found in the library.
+
+In future, we should be replacing this library with `mailchimp/transactional`. https://github.com/mailchimp/mailchimp-transactional-php

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
-    "name": "mandrill/mandrill",
+    "name": "asknicely/mandrill",
     "type": "library",
-    "version": "1.0.55",
-    "description": "Deprecated API client library for the Mandrill email as a service platform. Replaced by mailchimp/transactional",
+    "version": "2.0.0",
+    "description": "API client library for the Mandrill email as a service platform.",
     "keywords": ["email", "api"],
     "homepage": "https://bitbucket.org/mailchimp/mandrill-api-php",
     "license": "Apache-2.0",

--- a/src/Mandrill.php
+++ b/src/Mandrill.php
@@ -18,11 +18,27 @@ require_once 'Mandrill/Metadata.php';
 require_once 'Mandrill/Exceptions.php';
 
 class Mandrill {
-    
+
     public $apikey;
     public $ch;
     public $root = 'https://mandrillapp.com/api/1.0';
     public $debug = false;
+
+    public $templates;
+    public $exports;
+    public $users;
+    public $rejects;
+    public $inbound;
+    public $tags;
+    public $messages;
+    public $whitelists;
+    public $ips;
+    public $internal;
+    public $subaccounts;
+    public $urls;
+    public $webhooks;
+    public $senders;
+    public $metadata;
 
     public static $error_map = array(
         "ValidationError" => "Mandrill_ValidationError",
@@ -127,7 +143,7 @@ class Mandrill {
         }
         $result = json_decode($response_body, true);
         if($result === null) throw new Mandrill_Error('We were unable to decode the JSON response from the Mandrill API: ' . $response_body);
-        
+
         if(floor($info['http_code'] / 100) >= 4) {
             throw $this->castError($result);
         }

--- a/src/Mandrill/Exports.php
+++ b/src/Mandrill/Exports.php
@@ -1,6 +1,9 @@
 <?php
 
 class Mandrill_Exports {
+
+    public $master;
+
     public function __construct(Mandrill $master) {
         $this->master = $master;
     }

--- a/src/Mandrill/Inbound.php
+++ b/src/Mandrill/Inbound.php
@@ -1,6 +1,9 @@
 <?php
 
 class Mandrill_Inbound {
+
+    public $master;
+
     public function __construct(Mandrill $master) {
         $this->master = $master;
     }

--- a/src/Mandrill/Internal.php
+++ b/src/Mandrill/Internal.php
@@ -1,6 +1,9 @@
 <?php
 
 class Mandrill_Internal {
+
+    public $master;
+
     public function __construct(Mandrill $master) {
         $this->master = $master;
     }

--- a/src/Mandrill/Ips.php
+++ b/src/Mandrill/Ips.php
@@ -1,6 +1,9 @@
 <?php
 
 class Mandrill_Ips {
+
+    public $master;
+
     public function __construct(Mandrill $master) {
         $this->master = $master;
     }

--- a/src/Mandrill/Messages.php
+++ b/src/Mandrill/Messages.php
@@ -1,6 +1,9 @@
 <?php
 
 class Mandrill_Messages {
+
+    public $master;
+
     public function __construct(Mandrill $master) {
         $this->master = $master;
     }

--- a/src/Mandrill/Metadata.php
+++ b/src/Mandrill/Metadata.php
@@ -1,6 +1,9 @@
 <?php
 
 class Mandrill_Metadata {
+
+    public $master;
+
     public function __construct(Mandrill $master) {
         $this->master = $master;
     }

--- a/src/Mandrill/Rejects.php
+++ b/src/Mandrill/Rejects.php
@@ -1,6 +1,9 @@
 <?php
 
 class Mandrill_Rejects {
+
+    public $master;
+
     public function __construct(Mandrill $master) {
         $this->master = $master;
     }

--- a/src/Mandrill/Senders.php
+++ b/src/Mandrill/Senders.php
@@ -1,6 +1,9 @@
 <?php
 
 class Mandrill_Senders {
+
+    public $master;
+
     public function __construct(Mandrill $master) {
         $this->master = $master;
     }

--- a/src/Mandrill/Subaccounts.php
+++ b/src/Mandrill/Subaccounts.php
@@ -1,6 +1,9 @@
 <?php
 
 class Mandrill_Subaccounts {
+
+    public $master;
+
     public function __construct(Mandrill $master) {
         $this->master = $master;
     }

--- a/src/Mandrill/Tags.php
+++ b/src/Mandrill/Tags.php
@@ -1,6 +1,9 @@
 <?php
 
 class Mandrill_Tags {
+
+    public $master;
+
     public function __construct(Mandrill $master) {
         $this->master = $master;
     }

--- a/src/Mandrill/Templates.php
+++ b/src/Mandrill/Templates.php
@@ -1,6 +1,9 @@
 <?php
 
 class Mandrill_Templates {
+
+    public $master;
+
     public function __construct(Mandrill $master) {
         $this->master = $master;
     }

--- a/src/Mandrill/Urls.php
+++ b/src/Mandrill/Urls.php
@@ -1,6 +1,9 @@
 <?php
 
 class Mandrill_Urls {
+
+    public $master;
+
     public function __construct(Mandrill $master) {
         $this->master = $master;
     }

--- a/src/Mandrill/Users.php
+++ b/src/Mandrill/Users.php
@@ -1,6 +1,9 @@
 <?php
 
 class Mandrill_Users {
+
+    public $master;
+
     public function __construct(Mandrill $master) {
         $this->master = $master;
     }

--- a/src/Mandrill/Webhooks.php
+++ b/src/Mandrill/Webhooks.php
@@ -1,6 +1,9 @@
 <?php
 
 class Mandrill_Webhooks {
+
+    public $master;
+
     public function __construct(Mandrill $master) {
         $this->master = $master;
     }

--- a/src/Mandrill/Whitelists.php
+++ b/src/Mandrill/Whitelists.php
@@ -1,6 +1,9 @@
 <?php
 
 class Mandrill_Whitelists {
+
+    public $master;
+
     public function __construct(Mandrill $master) {
         $this->master = $master;
     }


### PR DESCRIPTION
This PR does a few things

1. Adds properties to classes as the original package was assigning values to dynamic properties. Which is not allowed in PHP 8.2. NOTE: They have been made public to avoid any instances of visibility issues in other code. Dynamic properties were public anyway.
2. Changes to composer.json to suit new repo
3. New Readme for info