### PR TITLE
WEB-13594: Run destruct only when curl is available

### DIFF
--- a/src/Mandrill.php
+++ b/src/Mandrill.php
@@ -107,7 +107,9 @@ class Mandrill {
     }
 
     public function __destruct() {
-        curl_close($this->ch);
+        if ($this->ch) {
+            curl_close($this->ch);
+        }
     }
 
     public function call($url, $params) {


### PR DESCRIPTION
There are errors in the tests for `asknicelydo` for the new PHPUnit10 upgrade. It is hard to mock the `__destruct` method as it is a special function in PHP.  

See errors: https://github.com/asknicely/asknicelydo/actions/runs/8871131944/job/24353702075?pr=20037#step:7:783
```
There were 9 errors:

1) AskNicely\Digest\DigestServiceTest::testConstructor
TypeError: curl_close(): Argument #1 ($handle) must be of type CurlHandle, null given

/var/task/vendor/asknicely/mandrill/src/Mandrill.php:110
/var/task/tests/unit/Digest/DigestServiceTest.php:121

2) AskNicely\Digest\DigestServiceTest::testProcessAll
TypeError: curl_close(): Argument #1 ($handle) must be of type CurlHandle, null given

/var/task/vendor/asknicely/mandrill/src/Mandrill.php:110
/var/task/tests/unit/Digest/DigestServiceTest.php:121

3) AskNicely\Digest\DigestServiceTest::testProcessUserRoleDigests
TypeError: curl_close(): Argument #1 ($handle) must be of type CurlHandle, null given

/var/task/vendor/asknicely/mandrill/src/Mandrill.php:110
/var/task/tests/unit/Digest/DigestServiceTest.php:121

4) AskNicely\Digest\DigestServiceTest::testGetContent
TypeError: curl_close(): Argument #1 ($handle) must be of type CurlHandle, null given

/var/task/vendor/asknicely/mandrill/src/Mandrill.php:110
/var/task/tests/unit/Digest/DigestServiceTest.php:121

5) AskNicely\Digest\DigestServiceTest::testSendingFromPrimaryContact
TypeError: curl_close(): Argument #1 ($handle) must be of type CurlHandle, null given

/var/task/vendor/asknicely/mandrill/src/Mandrill.php:110
/var/task/tests/unit/Digest/DigestServiceTest.php:121

6) AskNicely\Digest\DigestServiceTest::testListForUser
TypeError: curl_close(): Argument #1 ($handle) must be of type CurlHandle, null given

/var/task/vendor/asknicely/mandrill/src/Mandrill.php:110
/var/task/tests/unit/Digest/DigestServiceTest.php:121

7) AskNicely\Digest\DigestServiceTest::testCreate
TypeError: curl_close(): Argument #1 ($handle) must be of type CurlHandle, null given

/var/task/vendor/asknicely/mandrill/src/Mandrill.php:110
/var/task/tests/unit/Digest/DigestServiceTest.php:121

8) AskNicely\Digest\DigestServiceTest::testPatch
TypeError: curl_close(): Argument #1 ($handle) must be of type CurlHandle, null given

/var/task/vendor/asknicely/mandrill/src/Mandrill.php:110
/var/task/tests/unit/Digest/DigestServiceTest.php:121

9) AskNicely\Digest\DigestServiceTest::testDelete
TypeError: curl_close(): Argument #1 ($handle) must be of type CurlHandle, null given

/var/task/vendor/asknicely/mandrill/src/Mandrill.php:110
/var/task/tests/unit/Digest/DigestServiceTest.php:121
```