### PR TITLE
WEB-14680 cURL set HTTP version to 1.1

### DIFF
--- a/src/Mandrill.php
+++ b/src/Mandrill.php
@@ -86,6 +86,7 @@ class Mandrill {
         curl_setopt($this->ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($this->ch, CURLOPT_CONNECTTIMEOUT, 30);
         curl_setopt($this->ch, CURLOPT_TIMEOUT, 600);
+        curl_setopt($this->ch, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
 
         $this->root = rtrim($this->root, '/') . '/';
 


### PR DESCRIPTION
An increased number of requests are failing with this error ([BugSnag](https://app.bugsnag.com/asknicely/asknicely-app-php/errors/64623077421bf4000932276c?filters[event.since]=all&filters[error.status]=open&filters[search]=mandrill)):
```
Mandrill_HttpError API call to messages/send failed: HTTP/2 send again with decreased length
```

This is an issue with cURL where a large header (>4kb) will cause an error, see [issue](https://github.com/curl/curl/issues/11138). A workaround is to use HTTP/1.1.

[WEB-14680](https://asknice.atlassian.net/browse/WEB-14680)